### PR TITLE
fix: stop caching calibratedRecords

### DIFF
--- a/FeatureEngine-benchmark/src/main/scala/org/oceandataexplorer/engine/benchmark/SPM.scala
+++ b/FeatureEngine-benchmark/src/main/scala/org/oceandataexplorer/engine/benchmark/SPM.scala
@@ -121,7 +121,6 @@ object SPM {
 
     val calibratedRecords: RDD[Record] = records
       .mapValues(chan => chan.map(calibrationClass.compute))
-      .persist(StorageLevel.MEMORY_AND_DISK)
 
     val welchSplWorkflow = new WelchSplWorkflow(
       spark,


### PR DESCRIPTION
It causes OOM when there is no disk volumes to spill on.